### PR TITLE
Automate Versioning on Merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,4 +67,4 @@ jobs:
           fi
 
       - name: Bump version and tag
-        run: ./scripts/bump-version.sh --${{ steps.bump.outputs.type }}
+        run: ./scripts/bump-version.sh "--${{ steps.bump.outputs.type }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,3 +37,34 @@ jobs:
         
       - name: Run API Client Tests
         run: yarn workspace @mbari/api-client test
+
+  bump-version:
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+      - name: Determine bump type
+        id: bump
+        run: |
+          git fetch --tags --prune
+          commit_msg="$(git show -s --format=%B ${{ github.event.pull_request.head.sha }})"
+          if echo "$commit_msg" | grep -iq "#major"; then
+            echo "type=major" >> "$GITHUB_OUTPUT"
+          elif echo "$commit_msg" | grep -iq "#minor"; then
+            echo "type=minor" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump version and tag
+        run: ./scripts/bump-version.sh --${{ steps.bump.outputs.type }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
   push:
     tags:
       - 'v*'  # Run when a version tag is pushed
+  # Tags are created automatically when PRs merge into develop
   release:
     types: [created]
 


### PR DESCRIPTION
This PR adds an explicit action to the build.yml to run the bump-version.sh script when PRs are merged to develop. The default bump is patch unless the author has tagged the last commit in the PR to be `minor` or `major`. Since this is a GH action we may have to do some trial and error here on GH to ensure it triggers as expected.

